### PR TITLE
Fix export for commonjs

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -1,3 +1,3 @@
 const { WebSocket } = require('ws')
 
-export { WebSocket }
+module.exports = WebSocket;


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Currently, commonjs projects will be hit with the following error:
```
/.../node_modules/unws/src/node.js:3
export { WebSocket }
^^^^^^

SyntaxError: Unexpected token 'export'
```

By replacing the export statement with `module.export` for the commonjs `node.js` fiel, I am quite positive that this PR should solve that issue. 

I tested this on Node `v16.16.0` & `v18.14.2` with a `commonjs` and a `module` project and lastly with a nodejs (index.js) script and a typescript (index.ts) script via `ts-node`. All combinations of what I mentioned here.

### Linked Issues

--
### Additional context

--
<!-- e.g. is there anything you'd like reviewers to focus on? -->
